### PR TITLE
Lock bun version

### DIFF
--- a/Dockerfile.package-backend
+++ b/Dockerfile.package-backend
@@ -1,4 +1,4 @@
-FROM oven/bun:1 AS build
+FROM oven/bun:1.2.5 AS build
 
 WORKDIR /app
 

--- a/Dockerfile.package-web
+++ b/Dockerfile.package-web
@@ -1,4 +1,4 @@
-FROM oven/bun:1 AS build
+FROM oven/bun:1.2.5 AS build
 
 WORKDIR /app
 

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "engines": {
     "node": ">=18"
   },
-  "packageManager": "bun@1.1.29",
+  "packageManager": "bun@1.2.5",
   "workspaces": [
     "apps/*",
     "packages/*"


### PR DESCRIPTION
Bun 1.2.6 breaks the frontend app, we choose to lock runtime version from now.