### PR TITLE
feat(web): add a way for getting client side app config at runtime

### DIFF
--- a/apps/web/env.d.ts
+++ b/apps/web/env.d.ts
@@ -1,5 +1,6 @@
 declare namespace NodeJS {
 	interface ProcessEnv {
+		NEXT_PUBLIC_BUILD_ID: string;
 		API_ROOT: string;
 		TEXTURE_STORE_ROOT: string;
 		JWT_SECRET: string;

--- a/apps/web/libs/actions/get-client-site-config.ts
+++ b/apps/web/libs/actions/get-client-site-config.ts
@@ -1,0 +1,7 @@
+'use server';
+
+import { getClientAppConfig } from '../utils/app-config';
+
+export async function getClientAppConfigAction() {
+	return getClientAppConfig();
+}

--- a/apps/web/libs/basicui/TextureCard/index.tsx
+++ b/apps/web/libs/basicui/TextureCard/index.tsx
@@ -3,6 +3,7 @@ import { Card, CardContent, CardFooter, CardHeader } from '@repo/ui/card';
 import { DataList, DataListItem, DataListLabel, DataListValue } from '@repo/ui/data-list';
 import { InlineCode, Large } from '@repo/ui/typography';
 import Image from 'next/image';
+import { useClientAppConfig } from '~web/libs/hooks/use-config';
 export type Props = {
 	texture: {
 		type: 'cape' | 'skin' | 'skin_slim';
@@ -16,6 +17,8 @@ export type Props = {
 };
 
 export function TextureCard({ texture, children }: Props) {
+	const clientAppConfig = useClientAppConfig();
+
 	return (
 		<Card>
 			<CardHeader>
@@ -57,7 +60,7 @@ export function TextureCard({ texture, children }: Props) {
 						alt="Texture image"
 						width={64}
 						height={texture.type === 'cape' ? 32 : 64}
-						src={`${process.env.TEXTURE_STORE_ROOT}/${texture.hash.slice(0, 2)}/${texture.hash}`}
+						src={`${clientAppConfig.textureRoot}/${texture.hash.slice(0, 2)}/${texture.hash}`}
 						className=""
 						style={{
 							imageRendering: 'pixelated',

--- a/apps/web/libs/hooks/use-config.ts
+++ b/apps/web/libs/hooks/use-config.ts
@@ -1,0 +1,30 @@
+import { useQuery } from '@tanstack/react-query';
+import { getClientAppConfigAction } from '../actions/get-client-site-config';
+import {
+	defaultClientAppConfig,
+	getClientAppConfig,
+	type ClientAppConfig,
+} from '../utils/app-config';
+
+export function useClientAppConfig(): ClientAppConfig {
+	// Called on server side
+	if (typeof window === 'undefined') {
+		return getClientAppConfig();
+	}
+
+	// Client side
+	// eslint-disable-next-line react-hooks/rules-of-hooks
+	const query = useQuery({
+		queryFn: getClientAppConfigAction,
+		queryKey: ['clientAppConfig', process.env.NEXT_PUBLIC_BUILD_ID],
+		gcTime: Infinity,
+		staleTime: Infinity,
+	});
+
+	// [TODO] Show error screen if not cached, otherwise use the cached data and fail silently.
+	if (!query.data) {
+		return defaultClientAppConfig;
+	}
+
+	return query.data;
+}

--- a/apps/web/libs/modules/auth/components/SessionManager/index.tsx
+++ b/apps/web/libs/modules/auth/components/SessionManager/index.tsx
@@ -7,6 +7,7 @@ export function SessionManager() {
 	useQuery({
 		queryKey: ['session-info'],
 		queryFn: validateSession,
+		gcTime: Infinity,
 		staleTime: Infinity,
 		refetchOnWindowFocus: false,
 		retry: false,

--- a/apps/web/libs/utils/app-config.ts
+++ b/apps/web/libs/utils/app-config.ts
@@ -1,0 +1,13 @@
+export type ClientAppConfig = {
+	textureRoot: string;
+};
+
+export const defaultClientAppConfig: ClientAppConfig = {
+	textureRoot: '',
+};
+
+export function getClientAppConfig(): ClientAppConfig {
+	return {
+		textureRoot: process.env.TEXTURE_STORE_ROOT,
+	};
+}

--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -1,3 +1,7 @@
+import { randomUUID } from 'crypto';
+
+const BUILD_ID = process.env.NEXT_PUBLIC_BUILD_ID ?? randomUUID();
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
 	reactStrictMode: true,
@@ -18,6 +22,13 @@ const nextConfig = {
 		},
 	},
 	output: 'standalone',
+	// Embed random build id in public env
+	env: {
+		NEXT_PUBLIC_BUILD_ID: BUILD_ID,
+	},
+	async generateBuildId() {
+		return BUILD_ID;
+	},
 
 	// Type checking and linting should be in individual tasks.
 	eslint: {


### PR DESCRIPTION
Adds a unified way for getting client side app config. You can use it in both server components and client components.