### PR TITLE
chore: use ts-go for typechecking

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -44,7 +44,8 @@
         "dbaeumer.vscode-eslint",
         "esbenp.prettier-vscode",
         "editorconfig.editorconfig",
-        "bradlc.vscode-tailwindcss"
+        "bradlc.vscode-tailwindcss",
+        "typescriptteam.native-preview"
       ]
     }
   },

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -3,6 +3,7 @@
     "dbaeumer.vscode-eslint",
     "esbenp.prettier-vscode",
     "editorconfig.editorconfig",
-    "bradlc.vscode-tailwindcss"
+    "bradlc.vscode-tailwindcss",
+    "typescriptteam.native-preview"
   ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,7 @@
 {
   "files.associations": {
     "*.css": "tailwindcss"
-  }
+  },
+
+  "typescript.experimental.useTsgo": true
 }

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -7,6 +7,7 @@
     "build": "bun scripts/build.ts",
     "start": "cd dist && bun run index.js start --config ../config.development.yaml",
     "typecheck": "tsc --noEmit",
+    "typecheck:tsgo": "tsgo --noEmit",
     "lint": "bun run --cwd ../.. eslint apps/backend --max-warnings 0 --cache --cache-location apps/backend/.eslintcache",
     "migration:generate": "drizzle-kit generate",
     "migration:drop": "drizzle-kit drop",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -7,6 +7,7 @@
     "build": "next build",
     "start": "bun --env-file .env.development.local next start",
     "typecheck": "tsc --noEmit",
+    "typecheck:tsgo": "tsgo --noEmit",
     "lint": "bun run --cwd ../.. eslint apps/web --max-warnings 0 --cache --cache-location apps/web/.eslintcache"
   },
   "dependencies": {

--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,7 @@
       "name": "hetu",
       "devDependencies": {
         "@repo/eslint-config": "*",
+        "@typescript/native-preview": "^7.0.0-dev.20250815.1",
         "prettier": "^3.5.3",
         "prettier-plugin-tailwindcss": "^0.6.11",
         "turbo": "^2.5.3",
@@ -88,6 +89,7 @@
         "@eslint-react/eslint-plugin": "^1.49.0",
         "@next/eslint-plugin-next": "^15.3.2",
         "@tanstack/eslint-plugin-query": "^5.74.7",
+        "@typescript/native-preview": "^7.0.0-dev.20250815.1",
         "eslint": "^9.27.0",
         "eslint-config-prettier": "^10.1.5",
         "eslint-config-turbo": "^2.5.3",
@@ -765,6 +767,22 @@
     "@typescript-eslint/utils": ["@typescript-eslint/utils@8.32.1", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.7.0", "@typescript-eslint/scope-manager": "8.32.1", "@typescript-eslint/types": "8.32.1", "@typescript-eslint/typescript-estree": "8.32.1" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0", "typescript": ">=4.8.4 <5.9.0" } }, "sha512-DsSFNIgLSrc89gpq1LJB7Hm1YpuhK086DRDJSNrewcGvYloWW1vZLHBTIvarKZDcAORIy/uWNx8Gad+4oMpkSA=="],
 
     "@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.32.1", "", { "dependencies": { "@typescript-eslint/types": "8.32.1", "eslint-visitor-keys": "^4.2.0" } }, "sha512-ar0tjQfObzhSaW3C3QNmTc5ofj0hDoNQ5XWrCy6zDyabdr0TWhCkClp+rywGNj/odAFBVzzJrK4tEq5M4Hmu4w=="],
+
+    "@typescript/native-preview": ["@typescript/native-preview@7.0.0-dev.20250815.1", "", { "optionalDependencies": { "@typescript/native-preview-darwin-arm64": "7.0.0-dev.20250815.1", "@typescript/native-preview-darwin-x64": "7.0.0-dev.20250815.1", "@typescript/native-preview-linux-arm": "7.0.0-dev.20250815.1", "@typescript/native-preview-linux-arm64": "7.0.0-dev.20250815.1", "@typescript/native-preview-linux-x64": "7.0.0-dev.20250815.1", "@typescript/native-preview-win32-arm64": "7.0.0-dev.20250815.1", "@typescript/native-preview-win32-x64": "7.0.0-dev.20250815.1" }, "bin": { "tsgo": "bin/tsgo.js" } }, "sha512-CfhUvXJV0/y7MuXFLcUrf9ZpidHZmYvJxkhqbT/78oBR+AnJ4aHCdTn3VYK3UQ5pNFPpQjAINMjsx6nxGrEG/g=="],
+
+    "@typescript/native-preview-darwin-arm64": ["@typescript/native-preview-darwin-arm64@7.0.0-dev.20250815.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-WztIEPVrWAxyDl/F+dqRIclTVlx0XzfsXjQlMz9DuxIGesK4kh9EkC1hj8ZCaFKriv3dd/Ip1zHFnZN0XlOOew=="],
+
+    "@typescript/native-preview-darwin-x64": ["@typescript/native-preview-darwin-x64@7.0.0-dev.20250815.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-C8R5zw/U44ctcFtxTOo2dASmKMIaoRD8VAsFitrbwH+q5PtGKD92JWK3K6ZLV3axp2T4Gddc8qMNZkg0rD0TNg=="],
+
+    "@typescript/native-preview-linux-arm": ["@typescript/native-preview-linux-arm@7.0.0-dev.20250815.1", "", { "os": "linux", "cpu": "arm" }, "sha512-FjB6OD9n+tuEkIUwVpcKWOvBytmCuUiRC4LkMTTIuxg0zJnsVuPqPZCuNWr7VoVLJVYd21YOq7Ackh+AT43BDw=="],
+
+    "@typescript/native-preview-linux-arm64": ["@typescript/native-preview-linux-arm64@7.0.0-dev.20250815.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-67vQsqoWTzsuAOQGybggaBe7Fj3e2Ts1nVX79uHQc1sSTmbiK2T3s7RDJvL7FfdDgYf4fFocwgnsSuC2/bVV5w=="],
+
+    "@typescript/native-preview-linux-x64": ["@typescript/native-preview-linux-x64@7.0.0-dev.20250815.1", "", { "os": "linux", "cpu": "x64" }, "sha512-5/lFG0PvsytEYMhNr6s1O33gayTTkDmx/exhcgv0zxAj2S4J5fPYWryGfB6XjTSLUDpFfiF9VaYil1BYfcTxSA=="],
+
+    "@typescript/native-preview-win32-arm64": ["@typescript/native-preview-win32-arm64@7.0.0-dev.20250815.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-Nt1TrCtZvzlg42JUAPZzUsyHYjNNj7gupOmOM70SFJXYu/Yb78m4AKBoBXI6rnMYEiS+3SSaIqscSb6UZB9Cjw=="],
+
+    "@typescript/native-preview-win32-x64": ["@typescript/native-preview-win32-x64@7.0.0-dev.20250815.1", "", { "os": "win32", "cpu": "x64" }, "sha512-aVlzVKHpJ4BCiPgHUiz3cagxl6SZUUaLsQalnZ5U+t0WtmB6Eu5d7+0irkzTsIQ8jATOuGbNsNfmvFvEFKkPfw=="],
 
     "@unhead/schema": ["@unhead/schema@1.11.14", "https://registry.npmmirror.com/@unhead/schema/-/schema-1.11.14.tgz", { "dependencies": { "hookable": "^5.5.3", "zhead": "^2.2.4" } }, "sha512-V9W9u5tF1/+TiLqxu+Qvh1ShoMDkPEwHoEo4DKdDG6ko7YlbzFfDxV6el9JwCren45U/4Vy/4Xi7j8OH02wsiA=="],
 

--- a/package.json
+++ b/package.json
@@ -7,12 +7,14 @@
     "dev": "turbo dev",
     "start": "turbo start",
     "typecheck": "turbo typecheck --continue",
+    "typecheck:tsgo": "turbo typecheck:tsgo --continue",
     "lint": "turbo lint --continue",
     "format": "prettier --check \"**/*.{ts,tsx,js,jsx,mjs,cjs,json,yaml,md}\"",
     "format:fix": "prettier --write \"**/*.{ts,tsx,js,jsx,mjs,cjs,json,yaml,md}\""
   },
   "devDependencies": {
     "@repo/eslint-config": "*",
+    "@typescript/native-preview": "^7.0.0-dev.20250815.1",
     "prettier": "^3.5.3",
     "prettier-plugin-tailwindcss": "^0.6.11",
     "turbo": "^2.5.3",

--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -12,6 +12,7 @@
   },
   "private": true,
   "scripts": {
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "typecheck:tsgo": "tsgo --noEmit"
   }
 }

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -13,6 +13,7 @@
     "@eslint-react/eslint-plugin": "^1.49.0",
     "@next/eslint-plugin-next": "^15.3.2",
     "@tanstack/eslint-plugin-query": "^5.74.7",
+    "@typescript/native-preview": "^7.0.0-dev.20250815.1",
     "eslint": "^9.27.0",
     "eslint-config-prettier": "^10.1.5",
     "eslint-config-turbo": "^2.5.3",

--- a/packages/miniclap/package.json
+++ b/packages/miniclap/package.json
@@ -10,6 +10,7 @@
   "private": true,
   "scripts": {
     "typecheck": "tsc --noEmit",
+    "typecheck:tsgo": "tsgo --noEmit",
     "lint": "bun run --cwd ../.. eslint packages/miniclap --max-warnings 0 --cache --cache-location packages/miniclap/.eslintcache"
   }
 }

--- a/packages/pino-pretty-transport/package.json
+++ b/packages/pino-pretty-transport/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "typecheck": "tsc --noEmit",
+    "typecheck:tsgo": "tsgo --noEmit",
     "lint": "bun run --cwd ../.. eslint packages/pino-pretty-transport --max-warnings 0 --cache --cache-location packages/pino-pretty-transport/.eslintcache"
   },
   "exports": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "gen:component": "turbo gen react-component",
     "typecheck": "tsc --noEmit",
+    "typecheck:tsgo": "tsgo --noEmit",
     "lint": "bun run --cwd ../.. eslint packages/ui --max-warnings 0 --cache --cache-location packages/ui/.eslintcache"
   },
   "dependencies": {

--- a/turbo.json
+++ b/turbo.json
@@ -21,6 +21,11 @@
       "outputs": [".tsbuildinfo"]
     },
 
+    "typecheck:tsgo": {
+      "dependsOn": ["^typecheck:tsgo"],
+      "outputs": [".tsbuildinfo"]
+    },
+
     "lint": {
       "dependsOn": ["^lint"],
       "outputs": [".eslintcache"]


### PR DESCRIPTION
TypeScript ESLint still uses the old TS as of now.